### PR TITLE
Compare Mode

### DIFF
--- a/sbord/sbord.py
+++ b/sbord/sbord.py
@@ -39,8 +39,10 @@ def main(paths):
         for p in paths:
             active_paths[p] = st.sidebar.checkbox(p, value=True)
     else:
-        path_idx = st.sidebar.radio("logdir", list(range(len(paths))), index=0,
-        format_func=lambda idx: paths[idx])
+        if len(paths) == 1:
+            path_idx = 0
+        else:
+            path_idx = st.sidebar.radio("logdir", list(range(len(paths))), index=0, format_func=lambda idx: paths[idx])
         path = paths[path_idx]
         logdir = os.path.realpath(path).split("/")
         logdir = logdir[-1] if logdir[-1] else logdir[-2]


### PR DESCRIPTION
Added the functionality to give multiple paths to the path argument (e.g. `streamlit run sbord.py -- 2021*` or `streamlit run sbord.py -- 2021-10-14T22-04-13_birds_cycle_transformer/ 2021-10-16T09-38-40_birds_nocycle_transformer/`, but `streamlit run sbord.py` works as before). And a radio button to switch between these multiple logs in the previous modes.

Also added a mode to plot multiple curves from one or more logdirs, e.g. compare the validation loss of different experiments or compare the validation loss with the trainings loss.